### PR TITLE
Add "close" handler to scoped slot

### DIFF
--- a/src/component.js
+++ b/src/component.js
@@ -68,9 +68,13 @@ const component = {
   render(h) {
     return h(
       'div',
-      this.tostinis.map(({ type, message, html }) => {
+      this.tostinis.map(({ id, type, message, html }) => {
         return this.$scopedSlots.default 
-          ? this.$scopedSlots.default({ type, message })
+          ? this.$scopedSlots.default({ 
+            type, 
+            message,
+            close: () => this._remove(id)
+          })
           : h(
             'div',
             {


### PR DESCRIPTION
Injected "close" handler to scoped slot, so user can manually close toast in custom template (#13). Example:
```vue
<tostini-plate class="tostini-plate" v-slot="{ type, message, close }">
  <div class="tostini" :data-type="type">
    {{ message }}
    <button @click="close">OK</button>
  </div>
</tostini-plate>
```